### PR TITLE
Set required bleach version to < 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     install_requires=[
         'Django',
         'markdown',
-        'bleach >= 2.0',
+        'bleach >= 2.0, < 5.0.0',
     ],
 )


### PR DESCRIPTION
Add extra filter on the bleach requirement to only versions below 5.0.0 are allowed.

This is a quickfix for #35 