### PR TITLE
fix little errors in documentation

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -121,8 +121,8 @@ For example::
     MARKDOWNIFY = {
         "default": {
             "MARKDOWN_EXTENSIONS": [
-                "markdown.extensions.fenced_code', // dotted path
-                "fenced_code',  // also works
+                "markdown.extensions.fenced_code", # dotted path
+                "fenced_code",  # also works
             ]
         }
     }


### PR DESCRIPTION
opening with `"` and closing with `'` : fixed
using javascript comments (`//`) instead of python comments (`#`) : fixed